### PR TITLE
Fix GoogleLogin and XboxLive MSA in AppImage

### DIFF
--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -53,7 +53,7 @@ call_quirk build_msa
 build_component msa
 install_component msa
 reset_cmake_options
-add_cmake_options -DCMAKE_INSTALL_PREFIX=/usr
+add_cmake_options -DCMAKE_INSTALL_PREFIX=/usr -DMSA_DAEMON_PATH=.
 call_quirk build_mcpelauncher
 build_component mcpelauncher
 install_component mcpelauncher
@@ -92,6 +92,8 @@ check_run $LINUXDEPLOY_BIN --appdir $APP_DIR -i $BUILD_DIR/mcpelauncher-ui-qt.pn
 
 export QML_SOURCES_PATHS=$SOURCE_DIR/mcpelauncher-ui/mcpelauncher-ui-qt/qml/
 check_run $LINUXDEPLOY_PLUGIN_QT_BIN --appdir $APP_DIR
+
+cp -r /usr/lib/x86_64-linux-gnu/nss $APP_DIR/usr/lib/
 
 check_run $LINUXDEPLOY_BIN --appdir $APP_DIR --output appimage
 mv Minecraft*.AppImage output


### PR DESCRIPTION
- libnss didn't find its nss folder (fix google login and msa-ui-qt)
- `-DMSA_DAEMON_PATH=.` like on macOS DMG script fix finding it in the AppImage